### PR TITLE
Support Mojo alternate IO loop.

### DIFF
--- a/MANIFEST
+++ b/MANIFEST
@@ -28,6 +28,7 @@ t/Net-Curl-Promiser-AnyEvent_reuse.t
 t/Net-Curl-Promiser-IOAsync.t
 t/Net-Curl-Promiser-IOAsync_net_curl_easy_overload.t
 t/Net-Curl-Promiser-Mojo.t
+t/Net-Curl-Promiser-Mojo_alternate_ioloop.t
 t/Net-Curl-Promiser-Select.t
 t/Net-Curl-Promiser-Select_setopt_fail.t
 t/cancel_fail.t

--- a/lib/Net/Curl/Promiser/Backend.pm
+++ b/lib/Net/Curl/Promiser/Backend.pm
@@ -16,6 +16,8 @@ sub new {
     }, shift;
 }
 
+sub INIT_PROMISE {}
+
 sub cancel_handle {
     my ($self, $easy, $multi) = @_;
 
@@ -75,6 +77,7 @@ sub add_handle {
         $promise = $self->PROMISE_CLASS()->new( sub {
             $self->{'callbacks'}{$easy} = \@_;
         } );
+        $self->INIT_PROMISE($promise);
     }
 
     return $promise;

--- a/lib/Net/Curl/Promiser/Backend/Mojo.pm
+++ b/lib/Net/Curl/Promiser/Backend/Mojo.pm
@@ -19,6 +19,7 @@ sub new {
 
     my $self = $class->SUPER::new();
 
+    $self->{'_loop'} = $loop // Mojo::IOLoop->singleton;
     $self->{'_fhstore'} = Net::Curl::Promiser::FDFHStore->new();
 
     return $self;
@@ -26,10 +27,15 @@ sub new {
 
 #----------------------------------------------------------------------
 
+sub INIT_PROMISE {
+  my ($self, $promise) = @_;
+  $promise->ioloop($self->{'_loop'});
+}
+
 sub SET_TIMER {
     my ($self, $multi, $timeout_ms) = @_;
 
-    $self->{onetimer} = Mojo::IOLoop->timer(
+    $self->{onetimer} = $self->{'_loop'}->timer(
         $timeout_ms / 1000,
         sub {
             $self->time_out($multi);
@@ -38,8 +44,9 @@ sub SET_TIMER {
 }
 
 sub CLEAR_TIMER {
-    my ($ot) = delete $_[0]->{'onetimer'};
-    Mojo::IOLoop->remove($ot) if $ot;
+    my ($self) = @_;
+    my ($ot) = delete $self->{'onetimer'};
+    $self->{'_loop'}->remove($ot) if $ot;
 }
 
 sub _io {
@@ -48,7 +55,7 @@ sub _io {
     my $socket = $self->{'_watched_sockets'}{$fd} ||= do {
         my $s = $self->{'_fhstore'}->get_fh($fd);
 
-        Mojo::IOLoop->singleton->reactor->io(
+        $self->{'_loop'}->reactor->io(
             $s,
             sub {
                 $self->process(
@@ -61,7 +68,7 @@ sub _io {
         $s;
     };
 
-    Mojo::IOLoop->singleton->reactor->watch(
+    $self->{'_loop'}->reactor->watch(
         $socket,
         $read_yn,
         $write_yn,
@@ -98,7 +105,7 @@ sub STOP_POLL {
     my ($self, $fd) = @_;
 
     if (my $socket = delete $self->{'_watched_sockets'}{$fd}) {
-        Mojo::IOLoop->remove($socket);
+        $self->{'_loop'}->remove($socket);
     }
 
     return;

--- a/lib/Net/Curl/Promiser/Mojo.pm
+++ b/lib/Net/Curl/Promiser/Mojo.pm
@@ -2,6 +2,7 @@ package Net::Curl::Promiser::Mojo;
 
 use strict;
 use warnings;
+use Mojo::IOLoop;
 
 =encoding utf-8
 
@@ -11,6 +12,7 @@ Net::Curl::Promiser::Mojo - support for L<Mojolicious>
 
 =head1 SYNOPSIS
 
+    # Defaults to Mojo’s default loop but can accept a custom loop:
     my $promiser = Net::Curl::Promiser::Mojo->new();
 
     my $handle = Net::Curl::Easy->new();
@@ -43,6 +45,9 @@ as its promise implementation.
 This alias conforms to Mojo’s convention of postfixing C<_p> onto the end
 of promise-returning functions.
 
+=item * The constructor accepts an optional parameter specifying a particular
+Mojo::IOLoop object to be targeted by the promiser.
+
 =back
 
 =cut
@@ -60,7 +65,8 @@ use Net::Curl::Promiser::Backend::Mojo;
 #----------------------------------------------------------------------
 
 sub _INIT {
-    return Net::Curl::Promiser::Backend::Mojo->new();
+    my ($self, $args) = @_;
+    return Net::Curl::Promiser::Backend::Mojo->new(@$args);
 }
 
 1;

--- a/t/Net-Curl-Promiser-Mojo_alternate_ioloop.t
+++ b/t/Net-Curl-Promiser-Mojo_alternate_ioloop.t
@@ -1,0 +1,61 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+use autodie;
+
+use Test::More;
+use Test::FailWarnings -allow_deps => 1;
+
+use Net::Curl::Easy;
+
+use FindBin;
+use lib "$FindBin::Bin/lib";
+
+use MyServer;
+use ClientTest;
+
+my $test_count = 2 + $ClientTest::TEST_COUNT;
+
+plan tests => $test_count;
+
+SKIP: {
+    local $ENV{'MOJO_REACTOR'} = 'Mojo::Reactor::Poll';
+
+    eval { require Mojolicious; 1 } or skip "Mojolicious isn’t available: $@", $test_count;
+    diag "Mojolicious version: $Mojolicious::VERSION";
+
+    eval { require Mojo::IOLoop; 1 } or skip "Mojo::IOLoop isn’t available: $@", $test_count;
+    eval { require Mojo::Promise; 1 } or skip "Mojo::Promise isn’t available: $@", $test_count;
+    eval { my $p = Mojo::Promise->new( sub { } ); 1 } or skip "This Mojo::Promise isn’t ES6-compatible: $@", $test_count;
+
+    # Use a private loop.
+    my $loop = Mojo::IOLoop->new;
+
+    diag "Using loop class " . ref($loop->{reactor});
+
+    require Net::Curl::Promiser::Mojo;
+
+    my $server = MyServer->new();
+
+    my $port = $server->port();
+
+    my $promiser = Net::Curl::Promiser::Mojo->new($loop);
+
+    can_ok( $promiser, 'add_handle_p' );
+
+    my $promise = ClientTest::run($promiser, $port)->then( sub { print "big resolve\n" }, sub { $@ = shift; warn } );
+
+  SKIP: {
+        skip 'Using Promise::XS', 1 if $promise->isa('Promise::XS::Promise');
+        isa_ok( $promise, 'Mojo::Promise', 'promise object' );
+    }
+
+    my $pr2 = $promise->finally( sub { $loop->stop() } );
+
+    $loop->start();
+
+    $server->finish();
+}
+
+done_testing();


### PR DESCRIPTION
This commit introduces an optional Mojo::IOLoop parameter to the Mojo constructor.

Implementation requires to set a new promise's io loop accordingly: a new backend method INIT_PROMISE performs this operation.

A new Mojo test using an alternate loop is also provided.

Thanks for considering it,
Patrick